### PR TITLE
[EPICENTER-5222] Handle Error: Reconnected to CometD

### DIFF
--- a/src/adapters/cometd.ts
+++ b/src/adapters/cometd.ts
@@ -77,14 +77,6 @@ class CometdAdapter {
     }
 
     listenToMetaChannels() {
-        errorManager.registerHandler(
-            (error) => error.code === 'COMETD_RECONNECTED',
-            async(error: Fault) => {
-                if (isBrowser()) {
-                    console.warn('Cometd Reconnected. If you wish to react to this reconnection, register an error handler with identifier: error.code === "COMETD_RECONNECTED".', error);
-                }
-            }
-        );
         const connectListener = new Promise((resolve, reject) => {
             this.cometd.addListener(CONNECT_META_CHANNEL, (message: Message) => {
                 if (this.cometd.isDisconnected()) {

--- a/src/epicenter.ts
+++ b/src/epicenter.ts
@@ -10,6 +10,14 @@ import { errorManager, identification, isBrowser, Fault, EpicenterError } from '
 
 const UNAUTHORIZED = 401;
 errorManager.registerHandler(
+    (error) => error.code === 'COMETD_RECONNECTED',
+    async(error: Fault) => {
+        if (isBrowser()) {
+            console.warn('Cometd Reconnected. If you wish to react to this reconnection, register an error handler with identifier: error.code === "COMETD_RECONNECTED".', error);
+        }
+    }
+);
+errorManager.registerHandler(
     (error: Fault) => error.status === UNAUTHORIZED && error.code === 'AUTHENTICATION_EXPIRED',
     async(error: Fault) => {
         await authAdapter.removeLocalSession();


### PR DESCRIPTION
The following error manager change was necessary in order to have a handler that doesn't actually throw the error:
```
/* eslint-disable  @typescript-eslint/no-explicit-any */
type HandleFunction = <T>(error: Fault, retry: RetryFunction<T>) => Promise<any>
/* eslint-enable  @typescript-eslint/no-explicit-any */
```