### PR TITLE
EPILIBS-101 Update getVideoUrlByKey to match current API implementation

### DIFF
--- a/src/apis/video.ts
+++ b/src/apis/video.ts
@@ -70,7 +70,7 @@ export async function getVideoURLByKey(
     optionals: RoutingOptions = {}
 ): Promise<string> {
     return await new Router()
-        .get(`/video/${videoKey}/${file}`, optionals)
+        .get(`/video/url/${videoKey}/${file}`, optionals)
         .then(({ body }) => body);
 }
 


### PR DESCRIPTION
Now allows retrieval of archive.mp4 and transcript.json