### PR TITLE
Use more robust check to detect node

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-new-func */
 export const isBrowser = new Function('try {return this===window;}catch(e){ return false;}');
-export const isNode = new Function('try {return this===global;}catch(e){return false;}');
+export const isNode = new Function('try {(typeof process !== "undefined") && (typeof process.versions.node !== "undefined")}catch(e){return false;}');
 
 
 export const last = (strOrArr: string | Array<unknown>): unknown => strOrArr[strOrArr.length - 1];


### PR DESCRIPTION
This should protect from any libraries setting `global = window`, as our current check only looks that far. It's not a very frequent issue but it can cause a major headache if this is the case. This check should work for node versions as low as v0.10.

![Screen Shot 2023-06-27 at 15 09 29](https://github.com/forio/epicenter-libs/assets/23513486/9e6efaf8-aa8c-4190-b98d-7e3fb09de7ec)

![Screen Shot 2023-06-27 at 15 10 11](https://github.com/forio/epicenter-libs/assets/23513486/ab8efea5-5caa-495a-b013-d8857bdced6c)
