### PR TITLE
fix: `cometdAdapter` init only once

### DIFF
--- a/src/adapters/cometd.ts
+++ b/src/adapters/cometd.ts
@@ -21,7 +21,7 @@ let cometdInstance: CometD | undefined;
 class CometdAdapter {
 
     url = '';
-    initialization = false;
+    initialization: Promise<boolean> | undefined = undefined;
     subscriptions = new Map();
     isConnected = false;
 
@@ -118,7 +118,7 @@ class CometdAdapter {
 
     async init() {
         if (!this.initialization) {
-            this.initialization = await this.startup();
+            this.initialization = this.startup();
         }
         return this.initialization;
     }


### PR DESCRIPTION
Closes [EPILIBS-118](https://issues.forio.com/browse/EPILIBS-118)

Looking at the [relevant](https://github.com/forio/epicenter-libs/commit/d9c5f3758e4751b8b243cce438988d95b69e951b) [commits](https://github.com/forio/epicenter-libs/commit/9dd60aea0d49d9ae67abadafd37f465b16cb9372), it's pretty clear the introduction of `await` was an oversight.

In the current code, `this.initialization` starts `false` and isn't set to `true` until `this.startup()` resolves. That means later calls to `this.init()` that come in while the first `this.startup()` is in flight will pass the ` if (!this.initialization)` check and call `this.startup()` again.

The effect of this is multiple active `cometd` sockets, which leads to really undesirable behavior including competing subscription callbacks at the same scope.