### PR TITLE
refactor: generate session cookie path using account/project from config

### DIFF
--- a/src/utils/identification.ts
+++ b/src/utils/identification.ts
@@ -86,7 +86,7 @@ class Identification {
         const isCustomDomain = !isLocal && window.location.pathname.split('/')[1] !== 'app';
         const isEpicenterDomain = !isLocal && !isCustomDomain;
         if (objectType === 'user' && isEpicenterDomain) {
-            const { accountShortName, projectShortName } = mySession;
+            const { accountShortName, projectShortName } = config;
             const account = accountShortName ? `/${accountShortName}` : '';
             const project = account && projectShortName ? `/${projectShortName}` : '';
             return { ...base, path: `/app${account}${project}` };


### PR DESCRIPTION
It turns out this was actually a very small change in terms of code.  Deployed two projects to dev-2 using this version of the libs for testing:
https://epicenter-dev-2.forio.com/epicenter/forio-dev/julie-everest
https://epicenter-dev-2.forio.com/epicenter/forio-dev/julie-another-everest
I opened them both up in the same browser, was able to switch back and forth logging in/out with users with and without groups, both tabs behaved as expected, all cookie paths had the correct account and project.
