### PR TITLE
fix: move timeout query param to body in POST calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "epicenter-libs",
-  "version": "3.12.0",
+  "version": "3.28.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "epicenter-libs",
-      "version": "3.12.0",
+      "version": "3.28.2",
       "dependencies": {
         "cometd": "^4.0.9",
         "cross-fetch": "^3.0.6"

--- a/src/adapters/run.ts
+++ b/src/adapters/run.ts
@@ -505,13 +505,11 @@ export async function getVariables(
         return variableMap;
     }, {} as Record<string, unknown>);
 
-    const searchParams = { timeout };
     const uriComponent = hasMultiple ? '' : `/${runKey.length === 1 ? runKey[0] : runKey}`;
     const include = variables.join(';');
-    const body = hasMultiple ? { include, runKey } : { ritual, include };
+    const body = hasMultiple ? { runKey, include, timeout } : { ritual, include, timeout };
     const additional = ignorable ? { ignorable } : {};
     return await new Router()
-        .withSearchParams(searchParams)
         .post(`/run/variable${uriComponent}`, {
             body: {
                 ...body,
@@ -601,16 +599,13 @@ export async function getMetadata(
     } & RoutingOptions = {}
 ): Promise<Record<string, unknown>> {
     const {
-        timeout,
         ...routingOptions
     } = optionals;
     const include = metadata.join(';');
     const hasMultiple = Array.isArray(runKey) && runKey.length > 1;
-    const searchParams = { timeout };
 
     const runKeyArg = Array.isArray(runKey) ? runKey : [runKey];
     return await new Router()
-        .withSearchParams(searchParams)
         .post('/run/meta', {
             body: {
                 include,

--- a/tests/run.spec.js
+++ b/tests/run.spec.js
@@ -770,14 +770,13 @@ describe('Run APIs', () => {
             const { server, accountShortName, projectShortName } = GENERIC_OPTIONS;
             url.should.equal(`${server}/api/v${config.apiVersion}/${accountShortName}/${projectShortName}/run/variable/${RUN_KEY}`);
         });
-        it('Should pass non-generic options to URL search parameters and body', async() => {
-            await runAdapter.getVariables(RUN_KEY, VARIABLES, { timeout: 300, ritual: RITUAL.REANIMATE });
+        it('Should pass non-generic options to body', async() => {
+            const TIMEOUT = 300;
+            await runAdapter.getVariables(RUN_KEY, VARIABLES, { timeout: TIMEOUT, ritual: RITUAL.REANIMATE });
             const req = fakeServer.requests.pop();
-            const search = req.url.split('?')[1];
-            const searchParams = new URLSearchParams(search);
-            searchParams.get('timeout').should.equal('300');
             const body = JSON.parse(req.requestBody);
             body.ritual.should.equal(RITUAL.REANIMATE);
+            body.timeout.should.equal(TIMEOUT);
         });
         it('Should handle the use of multiple run keys in the request body', async() => {
             await runAdapter.getVariables([RUN_KEY, '987654321'], VARIABLES);
@@ -938,13 +937,6 @@ describe('Run APIs', () => {
             const url = req.url.split('?')[0];
             const { server, accountShortName, projectShortName } = GENERIC_OPTIONS;
             url.should.equal(`${server}/api/v${config.apiVersion}/${accountShortName}/${projectShortName}/run/meta`);
-        });
-        it('Should pass non-generic options to URL search parameters', async() => {
-            await runAdapter.getMetadata(RUN_KEY, METADATA, { timeout: 300 });
-            const req = fakeServer.requests.pop();
-            const search = req.url.split('?')[1];
-            const searchParams = new URLSearchParams(search);
-            searchParams.get('timeout').should.equal('300');
         });
         it('Should handle multiple run keys in the request body', async() => {
             await runAdapter.getMetadata([RUN_KEY, '987654321'], METADATA);


### PR DESCRIPTION
[EPILIBS-149](https://forio.atlassian.net/browse/EPILIBS-149)

`getVariables`: [POST call](https://forio.com/v3/epicenter/manager/encyclopedia/as/asciidoc_to_html/v3/run#_post_apiv3accountshortnameprojectshortnamerunvariable)
`getMetadata`: [POST call](https://forio.com/v3/epicenter/manager/encyclopedia/as/asciidoc_to_html/v3/run#_post_apiv3accountshortnameprojectshortnamerunmeta)

[EPILIBS-149]: https://forio.atlassian.net/browse/EPILIBS-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ