### PR TITLE
feat!: consolidate SSO link creation

### DIFF
--- a/src/adapters/authentication.ts
+++ b/src/adapters/authentication.ts
@@ -147,35 +147,21 @@ export async function regenerate(
     return session;
 }
 
-export async function sso(
-    optionals: RoutingOptions = {},
-): Promise<Session> {
-    const session = await new Router()
-        .get('/registration/sso', optionals)
-        .then(({ body }) => body);
-
-    identification.session = session;
-    return session;
-}
-
 /**
- * Retrieves the SAML link from the SSO configuration
+ * Compute an Epicenter URL string that will redirect to the app's SSO login page.
+ * SSO login destination configured separately.
+ * @param  protocol                 The SSO protocol to use.
+ * @param  [optionals]              Optional arguments; pass network call options overrides here.
+ * @returns URL string. GET expects 302 to SSO login destination.
+ * @example
+ * const href = epicenter.authAdapter.ssoHref('SAML');
+ * <a href={href}>Login with SSO</a>
  */
-export async function getSAMLLink(
-    optionals: RoutingOptions = {},
-): Promise<string> {
-    return await new Router()
-        .get('/registration/sso/saml', optionals)
-        .then(({ body }) => body);
-}
-
-/**
- * Generates and returns an epicenter URL that will redirect to the SAML url.
- */
-export function generateSAMLLINK(
+export function ssoHref(
+    protocol: 'SAML',
     optionals: RoutingOptions = {},
 ): string {
-    return new Router().getURL('/registration/sso/saml', optionals).toString();
+    return new Router().getURL(`/registration/sso/user/${protocol}`, optionals).toString();
 }
 
 /**

--- a/tests/authentication.spec.js
+++ b/tests/authentication.spec.js
@@ -75,4 +75,19 @@ describe('Authentication', () => {
             req.method.toUpperCase().should.equal('DELETE');
         });
     });
+    describe('authAdapter.ssoHref', () => {
+        it('Should accept `protocol`', async() => {
+            const protocol = 'SAML';
+            const href = authAdapter.ssoHref(protocol);
+            const url = href.split('?')[0];
+            url.should.equal(`${config.apiProtocol}://${config.apiHost}/api/v${config.apiVersion}/${ACCOUNT}/${PROJECT}/registration/sso/user/${protocol}`);
+        });
+        it('Should support generic URL options', async() => {
+            const protocol = 'SAML';
+            const href = authAdapter.ssoHref(protocol, GENERIC_OPTIONS);
+            const url = href.split('?')[0];
+            const { server, accountShortName, projectShortName } = GENERIC_OPTIONS;
+            url.should.equal(`${server}/api/v${config.apiVersion}/${accountShortName}/${projectShortName}/registration/sso/user/${protocol}`);
+        });
+    });
 });


### PR DESCRIPTION
I'd be surprised if `authAdapter.sso` and `authAdapter.getSAMLLink` ever worked as intended since the platform URLs in question are expected to redirect to HTML pages.

This PR consolidates down to one method, `authAdapter.ssoHref`, named so to indicate that its return should be used with e.g. anchor tags or `window.location.href`.

`ssoHref` parameterizes `protocol`, too. 