### PR TITLE
feat: add vaultAdapter.updateProperties method

### DIFF
--- a/src/adapters/vault.ts
+++ b/src/adapters/vault.ts
@@ -29,12 +29,12 @@ interface Items {
 }
 
 /**
- * Updates a vault,
+ * Updates a vault's items
  * @example
  * // Change the name of the first student object in the list of students in the vault to "Bob"
  * epicenter.vaultAdapter.update('00000166d59adcb0f497ddc1aad0270c0a62', { set: { 'students.0.name': 'Bob' } })
  * @param vaultKey      Vault key
- * @param items         Object with a set/push/pop field to update the vault with
+ * @param items         Object with a set/push/pop field to update the vault items with
  * @param [optionals]   Optional arguments; pass network call options overrides here.
  * @returns promise that resolves to the vault
  */
@@ -59,6 +59,44 @@ export async function update(
             ...routingOptions,
         }).then(({ body }) => body);
 }
+
+
+/**
+ * Updates a vault's properties
+ * @example
+ * import { vaultAdapter, ROLE } from 'epicenter-libs';
+ * vaultAdapter.update('00000166d59adcb0f497ddc1aad0270c0a62', {
+ *      allowChannel: true,
+ *      permit: {
+ *          readLock: ROLE.FACILITATOR,
+ *          writeLock: ROLE.FACILITATOR,
+ *      },
+ *      ttlSeconds: 3600,
+ * });
+ * @param vaultKey      Vault key
+ * @param update        Object with properties to update
+ * @param [optionals]   Optional arguments; pass network call options overrides here.
+ * @returns promise that resolves to the vault
+ */
+export async function updateProperties(
+    vaultKey: string,
+    update: {
+        mutationKey?: string,
+        allowChannel?: boolean,
+        permit?: Permit,
+        ttlSeconds?: number,
+    },
+    optionals: RoutingOptions = {},
+): Promise<Vault<unknown>> {
+    return await new Router()
+        .patch(`/vault/${vaultKey}`, {
+            body: {
+                ...update,
+            },
+            ...optionals,
+        }).then(({ body }) => body);
+}
+
 
 const NOT_FOUND = 404;
 export async function get(
@@ -166,7 +204,7 @@ export async function define(
         items?: Items,
         readLock?: keyof typeof ROLE,
         writeLock?: keyof typeof ROLE,
-        ttlSeconds?: string,
+        ttlSeconds?: number,
         mutationStrategy?: string,
         allowChannel?: boolean,
     } & RoutingOptions = {}
@@ -216,7 +254,7 @@ export async function create(
     optionals: {
         readLock?: keyof typeof ROLE,
         writeLock?: keyof typeof ROLE,
-        ttlSeconds?: string,
+        ttlSeconds?: number,
         mutationStrategy?: string,
     } & RoutingOptions = {}
 ): Promise<Vault<unknown>> {

--- a/tests/vault.spec.js
+++ b/tests/vault.spec.js
@@ -51,7 +51,7 @@ describe('Vault APIs', () => {
             set: { foo: 'bar' },
             push: {},
         };
-        it('Should do a PATCH', async() => {
+        it('Should do a PUT', async() => {
             await vaultAdapter.update(VAULT_KEY, UPDATE);
             const req = fakeServer.requests.pop();
             req.method.toUpperCase().should.equal('PUT');
@@ -80,6 +80,47 @@ describe('Vault APIs', () => {
         });
         testedMethods.push('update');
     });
+
+    describe('vaultAdapter.updateProperties', () => {
+        const VAULT_KEY = 'MOCK_VAULT_KEY';
+        const UPDATE = {
+            allowChannel: true,
+            permit: {
+                readLock: ROLE.FACILITATOR,
+                writeLock: ROLE.FACILITATOR,
+            },
+            ttlSeconds: 3600,
+        };
+        it('Should do a PATCH', async() => {
+            await vaultAdapter.updateProperties(VAULT_KEY, UPDATE);
+            const req = fakeServer.requests.pop();
+            req.method.toUpperCase().should.equal('PATCH');
+        });
+        it('Should have authorization', async() => {
+            await vaultAdapter.updateProperties(VAULT_KEY, UPDATE);
+            const req = fakeServer.requests.pop();
+            req.requestHeaders.should.have.property('authorization', `Bearer ${SESSION.token}`);
+        });
+        it('Should use the vault/vaultKey URL', async() => {
+            await vaultAdapter.updateProperties(VAULT_KEY, UPDATE);
+            const req = fakeServer.requests.pop();
+            req.url.should.equal(`https://${config.apiHost}/api/v${config.apiVersion}/${ACCOUNT}/${PROJECT}/vault/${VAULT_KEY}`);
+        });
+        it('Should support generic URL options', async() => {
+            await vaultAdapter.updateProperties(VAULT_KEY, UPDATE, GENERIC_OPTIONS);
+            const req = fakeServer.requests.pop();
+            const { server, accountShortName, projectShortName } = GENERIC_OPTIONS;
+            req.url.should.equal(`${server}/api/v${config.apiVersion}/${accountShortName}/${projectShortName}/vault/${VAULT_KEY}`);
+        });
+        it('Should send the update in the request body', async() => {
+            await vaultAdapter.updateProperties(VAULT_KEY, UPDATE);
+            const req = fakeServer.requests.pop();
+            const body = JSON.parse(req.requestBody);
+            body.should.deep.equal(UPDATE);
+        });
+        testedMethods.push('updateProperties');
+    });
+
     describe('vaultAdapter.get', () => {
         const VAULT_KEY = 'MOCK_VAULT_KEY';
         it('Should do a GET', async() => {


### PR DESCRIPTION
I would have rather had this method called `update` and the current update method be called `updateItems` or something, but that would be a breaking change and this is definitely in use in waaaayyyy too many projects to be doing that, so instead this one is called `updateProperties`.  ¯\\\_(ツ)\_/¯ 