### PR TITLE
fix: allow cjs importing compatability for proxy

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -168,5 +168,15 @@ export default [{
         // For older versions of node, using cjs
         dir: path.dirname(pkg.main),
         format: 'cjs',
+        plugins: [{
+            name: 'cjs-package-json',
+            generateBundle() {
+                this.emitFile({
+                    type: 'asset',
+                    fileName: 'package.json',
+                    source: JSON.stringify({ type: 'commonjs' }),
+                });
+            },
+        }],
     }],
 }];


### PR DESCRIPTION
I was having an issue where the recent version of epicenter-libs don't work on proxy servers because of the addition of `type: "module"` in package.json. The proxy server doesn't support ES import/export syntax.

This adds a small package.json in the build folder at /dist/cjs/ which enables compatibility with CJS on the proxy