### PR TITLE
EPILIBS-211: Task create contract — payload.target, failSafeTermination type, privilege docs

### DIFF
--- a/src/adapters/task.ts
+++ b/src/adapters/task.ts
@@ -55,6 +55,7 @@ export interface HttpTaskPayloadCreateInView<
     objectType: 'http';
     method: string;
     url: string;
+    target?: 'APPLICATION' | 'PROXY';
     body: B;
     headers?: H;
 }
@@ -80,6 +81,7 @@ export interface HttpTaskPayloadReadOutView<
     objectType: 'http';
     method?: string;
     url?: string;
+    target?: 'application' | 'proxy';
     body?: B;
     headers?: H;
 }
@@ -119,7 +121,7 @@ export interface TaskReadOutView<
 
 
 /**
- * Creates a task; requires support level authentication
+ * Creates a task; requires facilitator (or higher) privileges
  * Base URL: POST `https://forio.com/api/v3/{ACCOUNT}/{PROJECT}/task`
  *
  * @example
@@ -131,7 +133,8 @@ export interface TaskReadOutView<
  * const name = 'task-1-send-emails';
  * const payload = {
  *     method: 'POST',
- *     url: 'https://forio.com/app/forio-dev/test-project/send-out-emails',
+ *     url: '/send-out-emails',
+ *     target: 'PROXY', // fire at the project's proxy server; omit to fire at the app
  * };
  * const trigger = {
  *     value: '0 7 15 * * ?', // triggers on day 15 7am of each month
@@ -146,7 +149,8 @@ export interface TaskReadOutView<
  * @param name                                  Name of the task
  * @param payload                               An HTTP task object that will be executed when the task is triggered
  * @param payload.method                        Type of method to use with the HTTP request (e.g., 'GET', 'POST', 'PATCH')
- * @param payload.url                           The URL the HTTP request will be sent to
+ * @param payload.url                           Relative URL the HTTP request will be sent to; the task runner builds the full URL as `{host}{targetPath}/{account}/{project}{url}`
+ * @param [payload.target]                      Where the task fires: 'APPLICATION' (the project app, `/app`, the default) or 'PROXY' (the project's proxy server, `/proxy`)
  * @param [payload.body]                        The body of the HTTP request
  * @param [payload.headers]                     Headers to send along with the HTTP request
  * @param trigger                               Object that determines when to run the task (cron, offset, or date)
@@ -172,13 +176,14 @@ export async function create<
     payload: {
         method: string;
         url: string;
+        target?: 'APPLICATION' | 'PROXY';
         body?: B;
         headers?: H;
     },
     trigger: TaskTriggerCreateInView,
     optionals: {
         retryPolicy?: keyof typeof RETRY_POLICY;
-        failSafeTermination?: number;
+        failSafeTermination?: string;
         ttlSeconds?: number;
     } & RoutingOptions = {},
 ): Promise<TaskReadOutView<B, H>> {
@@ -209,7 +214,7 @@ export async function create<
 
 
 /**
- * Deletes a task (changes status to cancelled); requires support level authentication
+ * Deletes a task (changes status to cancelled); requires facilitator (or higher) privileges
  * Base URL: DELETE `https://forio.com/api/v3/{ACCOUNT}/{PROJECT}/task/{TASK_KEY}`
  *
  * @example
@@ -234,7 +239,7 @@ export async function destroy(
 
 
 /**
- * Gets a task by taskKey; requires support level authentication
+ * Gets a task by taskKey; requires facilitator (or higher) privileges
  * Base URL: GET `https://forio.com/api/v3/{ACCOUNT}/{PROJECT}/task/{TASK_KEY}`
  *
  * @example
@@ -259,7 +264,7 @@ export async function get<
 
 
 /**
- * Gets the history (100 most recent times it has triggered) of a task by taskKey; requires support level authentication
+ * Gets the history (100 most recent times it has triggered) of a task by taskKey; requires facilitator (or higher) privileges
  * Base URL: GET `https://forio.com/api/v3/{ACCOUNT}/{PROJECT}/task/history/{TASK_KEY}`
  *
  * @example
@@ -287,7 +292,7 @@ export async function getHistory<
 
 
 /**
- * Gets most recent 100 tasks related to the selected scope; requires support level authentication
+ * Gets most recent 100 tasks related to the selected scope; requires facilitator (or higher) privileges
  * Base URL: GET `https://forio.com/api/v3/{ACCOUNT}/{PROJECT}/task/in/{SCOPE_BOUNDARY}/{SCOPE_KEY}` or GET `https://forio.com/api/v3/{ACCOUNT}/{PROJECT}/task/in/{SCOPE_BOUNDARY}/{SCOPE_KEY}/{USER_KEY}`
  *
  * Note: Will retrieve all tasks that were CREATED in the specified scope. If something was created with episode scope, it will not be retrievable through group scoping.

--- a/tests/task.spec.js
+++ b/tests/task.spec.js
@@ -104,7 +104,7 @@ describe('taskAdapter', () => {
         it('Should pass optional parameters to the request body', async () => {
             const optionals = {
                 retryPolicy: 'RESCHEDULE',
-                failSafeTermination: 1234567890,
+                failSafeTermination: '2026-01-01T00:00:00.000Z',
                 ttlSeconds: 3600,
             };
             await taskAdapter.create(scope, name, payload, trigger, optionals);
@@ -114,6 +114,23 @@ describe('taskAdapter', () => {
             expect(body).toHaveProperty('retryPolicy', optionals.retryPolicy);
             expect(body).toHaveProperty('failSafeTermination', optionals.failSafeTermination);
             expect(body).toHaveProperty('ttlSeconds', optionals.ttlSeconds);
+        });
+
+        it('Should pass the payload target through to the request body', async () => {
+            const proxyPayload = { ...payload, target: 'PROXY' };
+            await taskAdapter.create(scope, name, proxyPayload, trigger);
+
+            const req = capturedRequests[capturedRequests.length - 1];
+            const body = JSON.parse(req.options.body);
+            expect(body.payload).toHaveProperty('target', 'PROXY');
+        });
+
+        it('Should omit target from the request body when not provided', async () => {
+            await taskAdapter.create(scope, name, payload, trigger);
+
+            const req = capturedRequests[capturedRequests.length - 1];
+            const body = JSON.parse(req.options.body);
+            expect(body.payload).not.toHaveProperty('target');
         });
 
         it('Should include userKey in scope if provided', async () => {


### PR DESCRIPTION
## What

Contract catch-ups in `taskAdapter` ([EPILIBS-211](https://forio.atlassian.net/browse/EPILIBS-211)):

1. **`payload.target`** (`'APPLICATION' | 'PROXY'`, [EPICENTER-6729](https://forio.atlassian.net/browse/EPICENTER-6729)) typed on `create` and both HTTP payload views (read view echoes lowercase). Previously it only worked by sneaking through the payload spread; TypeScript callers had to pre-declare objects to dodge excess-property checking.
2. **`failSafeTermination`: `number` → `string`** (ISO-8601) — the wire format the server consumes and echoes, and what the docstring already claimed. Callers today carry `toISOString() as unknown as number` casts.
3. **Privilege docs**: every method said "requires support level authentication"; the Task API resource is `@Facilitator`-gated end to end. The old wording pushes integrators toward unnecessary shared-secret proxy plumbing. Also documented that `payload.url` is relative and how the runner builds the fire URL (`{host}{targetPath}/{account}/{project}{url}`).

## Verification

- `npm run test:run`: 1001 passed, including new specs asserting `target` passes through to the request body (and is absent when omitted); optionals spec now sends an ISO-8601 `failSafeTermination`.
- `npm run type-check` clean.
- Live: built `dist/cjs`, created a task on epicenter-sandbox-1 with `target: 'PROXY'` and an ISO `failSafeTermination` using a facilitator session — server echoed `target: 'proxy'` and the ISO timestamp; probe task destroyed afterward.

## Notes

`failSafeTermination: number → string` is a type-level break for TS callers who passed epoch millis; the ISO string is the only wire format we have verified working against the live API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EPILIBS-211]: https://forio.atlassian.net/browse/EPILIBS-211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EPICENTER-6729]: https://forio.atlassian.net/browse/EPICENTER-6729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ