### PR TITLE
[codex] fix task adapter contract gaps

### DIFF
--- a/src/adapters/task.ts
+++ b/src/adapters/task.ts
@@ -1,18 +1,35 @@
-import type { RoutingOptions, Page } from '../utils/router';
-import type { GenericScope, GenericSearchOptions, Address } from '../utils/constants';
+import type { Address, GenericScope, GenericSearchOptions } from '../utils/constants';
+import type { Page, RoutingOptions } from '../utils/router';
 
-import Router from '../utils/router';
 import { parseFilterInput } from '../utils/filter-parser';
+import Router from '../utils/router';
 
 export enum RETRY_POLICY {
     DO_NOTHING = 'DO_NOTHING', // If the task fails, do nothing (this is the default)
-    RESCHEDULE = 'RESCHEDULE', // If the task fails retry at the next scheduled time point
-    FIRE_ON_FAIL_SAFE = 'FIRE_ON_FAIL_SAFE', // Will re-execute the task after it fails; how long until this occurs is equal to ttlSeconds
+    FIRE_ON_FAIL_SAFE = 'FIRE_ON_FAIL_SAFE', // Retry within the task's fail-safe execution window
 }
 
 // Generic type aliases for task adapter
 export type TaskPayloadBody = Record<string, unknown>;
 export type TaskPayloadHeaders = Record<string, string>;
+export type TaskHttpMethod =
+    | 'GET'
+    | 'POST'
+    | 'PUT'
+    | 'DELETE';
+export type TaskRetryPolicyReadOutView = 'do_nothing' | 'fire_on_fail_safe';
+export type TaskStatusReadOutView =
+    | 'initialized'
+    | 'triggered'
+    | 'succeeded'
+    | 'failed'
+    | 'cancelled'
+    | 'terminated';
+export type TaskAddressReadOutView = Partial<Address>;
+
+export interface TaskScopeReadOutView extends GenericScope {
+    userKey?: string;
+}
 
 // Status type for group status tasks
 export interface StatusReadOutView {
@@ -54,11 +71,12 @@ export interface HttpTaskPayloadCreateInView<
     H extends object = TaskPayloadHeaders,
 > {
     objectType: 'http';
-    method: string;
+    method: TaskHttpMethod;
     url: string;
     target?: 'APPLICATION' | 'PROXY';
     body: B;
     headers?: H;
+    timeoutSeconds?: number;
 }
 
 export interface GroupStatusTaskPayloadCreateInView {
@@ -74,17 +92,30 @@ export type TaskPayloadCreateInView<
     | HttpTaskPayloadCreateInView<B, H>
     | GroupStatusTaskPayloadCreateInView;
 
+export type HttpTaskPayloadCreateInput<
+    B extends object = TaskPayloadBody,
+    H extends object = TaskPayloadHeaders,
+> = Omit<HttpTaskPayloadCreateInView<B, H>, 'objectType'> & {
+    objectType?: 'http';
+};
+
+export type TaskPayloadCreateInput<
+    B extends object = TaskPayloadBody,
+    H extends object = TaskPayloadHeaders,
+> = HttpTaskPayloadCreateInput<B, H> | GroupStatusTaskPayloadCreateInView;
+
 // Payload type definitions for reading tasks
 export interface HttpTaskPayloadReadOutView<
     B extends object = TaskPayloadBody,
     H extends object = TaskPayloadHeaders,
 > {
     objectType: 'http';
-    method?: string;
+    method?: TaskHttpMethod;
     url?: string;
     target?: 'application' | 'proxy';
     body?: B;
     headers?: H;
+    timeoutSeconds?: number;
 }
 
 export interface GroupStatusTaskPayloadReadOutView {
@@ -107,19 +138,35 @@ export interface TaskReadOutView<
 > {
     taskKey?: string;
     name?: string;
-    status?: string;
+    status?: TaskStatusReadOutView;
     cron?: string;
     mutationKey?: string;
     failures?: number;
     successes?: number;
-    address?: Address;
+    address?: TaskAddressReadOutView;
     payload?: TaskPayloadReadOutView<B, H>;
-    scope?: GenericScope;
-    retryPolicy?: string;
+    scope?: TaskScopeReadOutView;
+    retryPolicy?: TaskRetryPolicyReadOutView;
     failSafeTermination?: string;
     ttlSeconds?: number;
 }
 
+export interface TaskHistoryReadOutView {
+    result?: string;
+    execution?: number;
+    response?: number;
+    success?: boolean;
+    taskId?: number;
+}
+
+export interface TaskPageOptions {
+    first?: number;
+    max?: number;
+}
+
+export interface TaskScopePageOptions extends TaskPageOptions {
+    sort?: string[];
+}
 
 /**
  * Creates a task; requires facilitator (or higher) privileges
@@ -136,6 +183,7 @@ export interface TaskReadOutView<
  *     method: 'POST',
  *     url: '/send-out-emails',
  *     target: 'PROXY', // fire at the project's proxy server; omit to fire at the app
+ *     body: {},
  * };
  * const trigger = {
  *     value: '0 7 15 * * ?', // triggers on day 15 7am of each month
@@ -148,12 +196,13 @@ export interface TaskReadOutView<
  * @param scope.scopeKey                        Scope key, a unique identifier tied to the scope. E.g., if your `scopeBoundary` is `GROUP`, your `scopeKey` will be your `groupKey`; for `EPISODE`, `episodeKey`, etc.
  * @param [scope.userKey]                       Key associated with the user
  * @param name                                  Name of the task
- * @param payload                               An HTTP task object that will be executed when the task is triggered
- * @param payload.method                        Type of method to use with the HTTP request (e.g., 'GET', 'POST', 'PATCH')
+ * @param payload                               An HTTP request or group-status change to execute when the task is triggered
+ * @param payload.method                        Type of method to use with the HTTP request (e.g., 'GET', 'POST')
  * @param payload.url                           Relative URL the HTTP request will be sent to; the task runner builds the full URL as `{host}{targetPath}/{account}/{project}{url}`
  * @param [payload.target]                      Where the task fires: 'APPLICATION' (the project app, `/app`, the default) or 'PROXY' (the project's proxy server, `/proxy`)
- * @param [payload.body]                        The body of the HTTP request
- * @param [payload.headers]                     Headers to send along with the HTTP request
+ * @param payload.body                          The JSON body of the HTTP request
+ * @param [payload.headers]                     Headers to send along with the HTTP request; must be non-empty when provided — omit rather than pass an empty object
+ * @param [payload.timeoutSeconds]               Request timeout in seconds (1–30)
  * @param trigger                               Object that determines when to run the task (cron, offset, or date)
  * @param [trigger.value]                       For cron: cron expression (e.g., '0 7 * * * ?'). For date: ISO-8601 date-time string
  * @param [trigger.objectType]                  Type of trigger: 'cron', 'offset', or 'date'
@@ -164,8 +213,8 @@ export interface TaskReadOutView<
  * @param [optionals.accountShortName]          Name of account (by default will be the account associated with the session)
  * @param [optionals.projectShortName]          Name of project (by default will be the project associated with the session)
  * @param [optionals.retryPolicy]               Specifies what to do should the task fail; see RETRY_POLICY
- * @param [optionals.failSafeTermination]       The ISO-8601 date-time when the task will be deleted regardless of any triggers; defaults to null
- * @param [optionals.ttlSeconds]                Max life expectancy of the task; used to determine if retrying the task is necessary
+ * @param [optionals.failSafeTermination]       ISO-8601 deadline after which the task terminates; the server defaults and caps this at one year from creation
+ * @param [optionals.ttlSeconds]                Execution fail-safe window in seconds; the server applies its configured minimum
  * @returns promise that resolves to the task object including the taskKey
  */
 export async function create<
@@ -174,13 +223,7 @@ export async function create<
 >(
     scope: { userKey?: string } & GenericScope,
     name: string,
-    payload: {
-        method: string;
-        url: string;
-        target?: 'APPLICATION' | 'PROXY';
-        body?: B;
-        headers?: H;
-    },
+    payload: TaskPayloadCreateInput<B, H>,
     trigger: TaskTriggerCreateInView,
     optionals: {
         retryPolicy?: keyof typeof RETRY_POLICY;
@@ -194,12 +237,16 @@ export async function create<
         ttlSeconds,
         ...routingOptions
     } = optionals;
+    const normalizedPayload: TaskPayloadCreateInView<B, H> =
+        payload.objectType === 'groupStatus' ?
+            payload :
+            { ...payload, objectType: 'http' };
     return await new Router()
         .post(
             '/task',
             {
                 body: {
-                    payload: { objectType: 'http' as const, ...payload },
+                    payload: normalizedPayload,
                     trigger,
                     retryPolicy,
                     failSafeTermination,
@@ -224,7 +271,7 @@ export async function create<
  * await taskAdapter.destroy(taskKey);
  *
  * @param taskKey                               Unique key associated with a task
- * @param [optionals]                           Optional arguments; pass network call options overrides here. Special arguments specific to this method are listed below if they exist.
+ * @param [optionals]                           Optional arguments; pass network call options overrides here.
  * @param [optionals.accountShortName]          Name of account (by default will be the account associated with the session)
  * @param [optionals.projectShortName]          Name of project (by default will be the project associated with the session)
  * @returns promise that resolves to undefined when successful
@@ -249,7 +296,7 @@ export async function destroy(
  * const task = await taskAdapter.get(taskKey);
  *
  * @param taskKey                               Unique key associated with a task
- * @param [optionals]                           Optional arguments; pass network call options overrides here. Special arguments specific to this method are listed below if they exist.
+ * @param [optionals]                           Optional arguments; pass network call options overrides here.
  * @param [optionals.accountShortName]          Name of account (by default will be the account associated with the session)
  * @param [optionals.projectShortName]          Name of project (by default will be the project associated with the session)
  * @returns promise that resolves to the task object
@@ -274,20 +321,24 @@ export async function get<
  * const history = await taskAdapter.getHistory(taskKey);
  *
  * @param taskKey                               Unique key associated with a task
- * @param [optionals]                           Optional arguments; pass network call options overrides here. Special arguments specific to this method are listed below if they exist.
+ * @param [optionals]                           Pagination and network options
+ * @param [optionals.first]                     Zero-based index of the first history record; defaults to 0
+ * @param [optionals.max]                       Maximum history records to return; defaults to 100 and cannot exceed 100
  * @param [optionals.accountShortName]          Name of account (by default will be the account associated with the session)
  * @param [optionals.projectShortName]          Name of project (by default will be the project associated with the session)
- * @returns promise that resolves to an array of task history objects
+ * @returns promise that resolves to a page of task history objects
  */
-export async function getHistory<
-    B extends object = TaskPayloadBody,
-    H extends object = TaskPayloadHeaders,
->(
+export async function getHistory(
     taskKey: string,
-    optionals: RoutingOptions = {},
-): Promise<TaskReadOutView<B, H>[]> {
+    optionals: TaskPageOptions & RoutingOptions = {},
+): Promise<Page<TaskHistoryReadOutView>> {
+    const { first, max, ...routingOptions } = optionals;
     return await new Router()
-        .get(`/task/history/${taskKey}`, optionals)
+        .withSearchParams({ first, max })
+        .get(`/task/history/${taskKey}`, {
+            paginated: true,
+            ...routingOptions,
+        })
         .then(({ body }) => body);
 }
 
@@ -310,25 +361,37 @@ export async function getHistory<
  * @param scope.scopeBoundary                   Scope boundary, defines the type of scope; See [scope boundary](#SCOPE_BOUNDARY) for all types
  * @param scope.scopeKey                        Scope key, a unique identifier tied to the scope. E.g., if your `scopeBoundary` is `GROUP`, your `scopeKey` will be your `groupKey`; for `EPISODE`, `episodeKey`, etc.
  * @param [scope.userKey]                       Key associated with the user; will retrieve tasks in the scope that were made by the specified user
- * @param [optionals]                           Optional arguments; pass network call options overrides here. Special arguments specific to this method are listed below if they exist.
+ * @param [optionals]                           Pagination, sorting, and network options
+ * @param [optionals.sort]                      Task fields to sort by
+ * @param [optionals.first]                     Zero-based index of the first task; defaults to 0
+ * @param [optionals.max]                       Maximum tasks to return; defaults to 100 and cannot exceed 100
  * @param [optionals.accountShortName]          Name of account (by default will be the account associated with the session)
  * @param [optionals.projectShortName]          Name of project (by default will be the project associated with the session)
- * @returns promise that resolves to an array of task objects
+ * @returns promise that resolves to a page of task objects
  */
 export async function getTaskIn<
     B extends object = TaskPayloadBody,
     H extends object = TaskPayloadHeaders,
 >(
     scope: { userKey?: string } & GenericScope,
-    optionals: RoutingOptions = {},
-): Promise<TaskReadOutView<B, H>[]> {
+    optionals: TaskScopePageOptions & RoutingOptions = {},
+): Promise<Page<TaskReadOutView<B, H>>> {
     const { scopeBoundary, scopeKey, userKey } = scope;
+    const { sort = [], first, max, ...routingOptions } = optionals;
     return await new Router()
+        .withSearchParams({
+            sort: sort.join(';') || undefined,
+            first,
+            max,
+        })
         .get(
             `/task/in/${scopeBoundary}/${scopeKey}${
                 userKey ? `/${userKey}` : ''
             }`,
-            optionals,
+            {
+                paginated: true,
+                ...routingOptions,
+            },
         )
         .then(({ body }) => body);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -234,6 +234,11 @@ export type {
     RETRY_POLICY,
     TaskPayloadBody,
     TaskPayloadHeaders,
+    TaskHttpMethod,
+    TaskRetryPolicyReadOutView,
+    TaskStatusReadOutView,
+    TaskAddressReadOutView,
+    TaskScopeReadOutView,
     StatusReadOutView,
     StatusCreateInView,
     CronTaskTriggerCreateInView,
@@ -243,10 +248,15 @@ export type {
     HttpTaskPayloadCreateInView,
     GroupStatusTaskPayloadCreateInView,
     TaskPayloadCreateInView,
+    HttpTaskPayloadCreateInput,
+    TaskPayloadCreateInput,
     HttpTaskPayloadReadOutView,
     GroupStatusTaskPayloadReadOutView,
     TaskPayloadReadOutView,
     TaskReadOutView,
+    TaskHistoryReadOutView,
+    TaskPageOptions,
+    TaskScopePageOptions,
 } from './adapters/task';
 
 // User Adapter

--- a/src/utils/router.ts
+++ b/src/utils/router.ts
@@ -45,6 +45,7 @@ export interface RetryFunction<Output> {
 export interface Page<Item> {
     firstResult: number;
     maxResults: number;
+    resultSize: number;
     totalResults: number;
     values: Item[];
     prev: () => Promise<Item[]>;

--- a/tests/task.spec.js
+++ b/tests/task.spec.js
@@ -22,6 +22,31 @@ import {
 } from './common';
 
 describe('taskAdapter', () => {
+    const TASK_HISTORY = {
+        result: 'response body',
+        execution: 1752768000000,
+        response: 1752768000100,
+        success: true,
+        taskId: 42,
+    };
+    const TASK = {
+        taskKey: 'TASK_KEY',
+        status: 'initialized',
+        retryPolicy: 'do_nothing',
+        payload: {
+            objectType: 'http',
+            method: 'POST',
+            url: '/send-out-emails',
+            target: 'proxy',
+            body: {},
+            timeoutSeconds: 10,
+        },
+        scope: {
+            scopeBoundary: SCOPE_BOUNDARY.GROUP,
+            scopeKey: 'GROUP_KEY',
+            userKey: 'USER_KEY',
+        },
+    };
     let capturedRequests = [];
     let mockSetup;
 
@@ -29,7 +54,26 @@ describe('taskAdapter', () => {
     config.projectShortName = PROJECT;
 
     beforeAll(() => {
-        mockSetup = createFetchMock();
+        mockSetup = createFetchMock({
+            '/task/history/': {
+                body: {
+                    firstResult: 0,
+                    maxResults: 100,
+                    resultSize: 1,
+                    totalResults: 1,
+                    values: [TASK_HISTORY],
+                },
+            },
+            '/task/in/': {
+                body: {
+                    firstResult: 0,
+                    maxResults: 100,
+                    resultSize: 1,
+                    totalResults: 1,
+                    values: [TASK],
+                },
+            },
+        });
         capturedRequests = mockSetup.capturedRequests;
     });
 
@@ -52,6 +96,7 @@ describe('taskAdapter', () => {
         const payload = {
             method: 'POST',
             url: '/send-out-emails',
+            body: {},
         };
         const trigger = {
             value: '0 7 15 * * ?',
@@ -103,7 +148,7 @@ describe('taskAdapter', () => {
 
         it('Should pass optional parameters to the request body', async () => {
             const optionals = {
-                retryPolicy: 'RESCHEDULE',
+                retryPolicy: 'FIRE_ON_FAIL_SAFE',
                 failSafeTermination: '2026-01-01T00:00:00.000Z',
                 ttlSeconds: 3600,
             };
@@ -123,6 +168,31 @@ describe('taskAdapter', () => {
             const req = capturedRequests[capturedRequests.length - 1];
             const body = JSON.parse(req.options.body);
             expect(body.payload).toHaveProperty('target', 'PROXY');
+        });
+
+        it('Should pass the payload timeout through to the request body', async () => {
+            const timeoutPayload = { ...payload, timeoutSeconds: 10 };
+            await taskAdapter.create(scope, name, timeoutPayload, trigger);
+
+            const req = capturedRequests[capturedRequests.length - 1];
+            const body = JSON.parse(req.options.body);
+            expect(body.payload).toHaveProperty('timeoutSeconds', 10);
+        });
+
+        it('Should preserve a group-status payload discriminator', async () => {
+            const groupStatusPayload = {
+                objectType: 'groupStatus',
+                groupKey: 'GROUP_KEY',
+                status: {
+                    code: 'COMPLETE',
+                    message: 'Complete',
+                },
+            };
+            await taskAdapter.create(scope, name, groupStatusPayload, trigger);
+
+            const req = capturedRequests[capturedRequests.length - 1];
+            const body = JSON.parse(req.options.body);
+            expect(body.payload).toEqual(groupStatusPayload);
         });
 
         it('Should omit target from the request body when not provided', async () => {
@@ -239,6 +309,20 @@ describe('taskAdapter', () => {
             expect(req.url).toBe(`${server}/api/v${config.apiVersion}/${accountShortName}/${projectShortName}/task/history/${taskKey}`);
         });
 
+        it('Should send pagination options and return task-history records in a page', async () => {
+            const page = await taskAdapter.getHistory(taskKey, { first: 0, max: 25 });
+            const req = capturedRequests[capturedRequests.length - 1];
+            const searchParams = new URL(req.url).searchParams;
+
+            expect(searchParams.get('first')).toBe('0');
+            expect(searchParams.get('max')).toBe('25');
+            expect(page.resultSize).toBe(1);
+            expect(page.values).toEqual([TASK_HISTORY]);
+            expect(typeof page.prev).toBe('function');
+            expect(typeof page.next).toBe('function');
+            expect(typeof page.all).toBe('function');
+        });
+
         testedMethods.add('getHistory');
     });
 
@@ -281,6 +365,25 @@ describe('taskAdapter', () => {
             const req = capturedRequests[capturedRequests.length - 1];
             const { server, accountShortName, projectShortName } = GENERIC_OPTIONS;
             expect(req.url).toBe(`${server}/api/v${config.apiVersion}/${accountShortName}/${projectShortName}/task/in/${scope.scopeBoundary}/${scope.scopeKey}`);
+        });
+
+        it('Should send sorting and pagination options and return tasks in a page', async () => {
+            const page = await taskAdapter.getTaskIn(scope, {
+                sort: ['-task.created', '+task.name'],
+                first: 0,
+                max: 25,
+            });
+            const req = capturedRequests[capturedRequests.length - 1];
+            const searchParams = new URL(req.url).searchParams;
+
+            expect(searchParams.get('sort')).toBe('-task.created;+task.name');
+            expect(searchParams.get('first')).toBe('0');
+            expect(searchParams.get('max')).toBe('25');
+            expect(page.resultSize).toBe(1);
+            expect(page.values).toEqual([TASK]);
+            expect(typeof page.prev).toBe('function');
+            expect(typeof page.next).toBe('function');
+            expect(typeof page.all).toBe('function');
         });
 
         testedMethods.add('getTaskIn');


### PR DESCRIPTION
## Summary

Completes the remaining `taskAdapter` contract gaps found by comparing the adapter with Epicenter 6.1.0's Task resource implementation.

This PR is stacked on #167. It intentionally does not add `/task/search`, which is already covered by #166.

## User impact

Before this change, the adapter exposed an invalid retry policy, omitted valid task payload forms and fields, modeled serialized read values too loosely or with the wrong casing, and treated paged Task endpoints as arrays. Consumers could construct requests rejected by Epicenter or receive TypeScript declarations that did not match realized responses.

## Changes

- Removes the unsupported `RESCHEDULE` retry policy.
- Models the exact HTTP method set, `timeoutSeconds`, and `groupStatus` create payload.
- Models serialized lowercase task status, retry policy, and payload target values.
- Includes `scope.userKey` and permits the partial address shape returned by Task reads.
- Adds the Task history result shape.
- Makes `/task/history/{taskKey}` and `/task/in/...` return `Page` values and exposes their pagination and sort parameters.
- Adds `resultSize` to the shared `Page` declaration to match the existing pagination response shape.
- Preserves the adapter-wide `RoutingOptions` last-write-wins override contract.

## Contract evidence

- Epicenter deployment: `epicenter-dev-monolith-1`, version 6.1.0.
- Reference implementation checkout: `c87d4a86d3ab10b3e51123b23462138e964c5c87`.
- Compared the Task resource create, history, and scoped-list endpoints with their create/read serializers and enum adapters.
- Tests cover representative HTTP and group-status creates, timeout propagation, serialized read shapes, pagination metadata, navigation helpers, and query construction.

## Verification

- `npm run test:run -- tests/task.spec.js` — 31 passed.
- `npm run test:run` — 32 files, 1,005 tests passed.
- `npm run build` — passed.
- `npx eslint src/adapters/task.ts src/types.ts src/utils/router.ts tests/task.spec.js` — passed.
- `git diff --check` — passed.
- The pre-push hook independently reran type-check, test build, and all 1,005 tests successfully.
